### PR TITLE
feat: add pre-commit hooks with Husky and lint-staged

### DIFF
--- a/.husky/commit-msg
+++ b/.husky/commit-msg
@@ -1,0 +1,1 @@
+npx --no -- commitlint --edit ${1}

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,0 +1,1 @@
+npx lint-staged

--- a/PRECOMMIT_SETUP.md
+++ b/PRECOMMIT_SETUP.md
@@ -1,0 +1,129 @@
+# Pre-commit Hooks Setup
+
+This project uses Husky and lint-staged to ensure code quality and consistency before commits.
+
+## What's Included
+
+### 1. Husky Pre-commit Hooks
+
+- **Pre-commit**: Runs lint-staged on staged files
+- **Commit-msg**: Validates commit messages using commitlint
+
+### 2. Lint-staged Configuration
+
+Automatically runs on staged files:
+
+- **JavaScript/TypeScript files** (`.js`, `.jsx`, `.ts`, `.tsx`):
+  - ESLint with auto-fix
+  - Prettier formatting
+- **Other files** (`.json`, `.css`, `.md`):
+  - Prettier formatting
+
+### 3. Conventional Commits
+
+- **Commitizen**: Interactive commit message creation
+- **Commitlint**: Validates commit message format
+
+## Usage
+
+### Making Commits
+
+Use the interactive commit tool for conventional commits:
+
+```bash
+npm run commit
+# or
+git cz
+```
+
+### Manual Linting and Formatting
+
+```bash
+# Lint and fix issues
+npm run lint:fix
+
+# Format all files
+npm run format
+
+# Check formatting without fixing
+npm run format:check
+```
+
+### Commit Message Format
+
+Follow conventional commit format:
+
+```
+<type>(<scope>): <description>
+
+[optional body]
+
+[optional footer(s)]
+```
+
+**Types:**
+
+- `feat`: New feature
+- `fix`: Bug fix
+- `docs`: Documentation changes
+- `style`: Code style changes (formatting, etc.)
+- `refactor`: Code refactoring
+- `perf`: Performance improvements
+- `test`: Adding or updating tests
+- `build`: Build system changes
+- `ci`: CI/CD changes
+- `chore`: Maintenance tasks
+- `revert`: Reverting changes
+
+**Examples:**
+
+```
+feat(auth): add user login functionality
+fix(ui): resolve button alignment issue
+docs: update API documentation
+chore: update dependencies
+```
+
+## How It Works
+
+1. **Before Commit**: When you run `git commit`, Husky triggers the pre-commit hook
+2. **Lint-staged**: Only processes staged files, running ESLint and Prettier
+3. **Auto-fix**: ESLint automatically fixes fixable issues
+4. **Format**: Prettier formats the code consistently
+5. **Validation**: If there are unfixable errors, the commit is blocked
+6. **Commit Message**: Commitlint validates the commit message format
+
+## Benefits
+
+- **Consistent Code Quality**: All code is linted and formatted before commits
+- **Clean Git History**: Only properly formatted code enters the repository
+- **Team Consistency**: Everyone follows the same coding standards
+- **Conventional Commits**: Standardized commit messages for better changelog generation
+- **Faster Reviews**: Less time spent on formatting issues in code reviews
+
+## Troubleshooting
+
+### Pre-commit Hook Fails
+
+If the pre-commit hook fails:
+
+1. Fix the linting errors shown in the output
+2. Re-stage the files: `git add <file>`
+3. Try committing again
+
+### Bypassing Hooks (Not Recommended)
+
+If you absolutely need to bypass hooks (emergency fixes):
+
+```bash
+git commit --no-verify -m "emergency fix"
+```
+
+### Updating Hooks
+
+To update the pre-commit configuration, modify:
+
+- `package.json` - lint-staged configuration
+- `.husky/pre-commit` - pre-commit hook script
+- `.husky/commit-msg` - commit message validation
+- `commitlint.config.js` - commit message rules

--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -1,0 +1,31 @@
+export default {
+  extends: ['@commitlint/config-conventional'],
+  rules: {
+    'type-enum': [
+      2,
+      'always',
+      [
+        'feat',
+        'fix',
+        'docs',
+        'style',
+        'refactor',
+        'perf',
+        'test',
+        'build',
+        'ci',
+        'chore',
+        'revert',
+      ],
+    ],
+    'subject-case': [
+      2,
+      'never',
+      ['sentence-case', 'start-case', 'pascal-case', 'upper-case'],
+    ],
+    'subject-empty': [2, 'never'],
+    'subject-full-stop': [2, 'never', '.'],
+    'type-case': [2, 'always', 'lower-case'],
+    'type-empty': [2, 'never'],
+  },
+};

--- a/package.json
+++ b/package.json
@@ -8,7 +8,11 @@
     "build": "next build",
     "start": "next start",
     "lint": "next lint",
-    "format": "prettier --write ."
+    "format": "prettier --write .",
+    "prepare": "husky",
+    "commit": "git-cz",
+    "lint:fix": "eslint --fix",
+    "format:check": "prettier --check ."
   },
   "dependencies": {
     "@fortawesome/fontawesome-svg-core": "^6.7.2",
@@ -47,18 +51,38 @@
     "tw-animate-css": "^1.2.4"
   },
   "devDependencies": {
+    "@commitlint/cli": "^20.0.0",
+    "@commitlint/config-conventional": "^20.0.0",
     "@eslint/eslintrc": "^3.3.1",
     "@types/node": "^20",
     "@types/react": "^19",
     "@types/react-dom": "^19",
     "autoprefixer": "^10.4.21",
+    "commitizen": "^4.3.1",
+    "cz-conventional-changelog": "^3.3.0",
     "eslint": "^8.57.1",
     "eslint-config-next": "^15.2.3",
     "eslint-config-prettier": "^10.1.1",
     "eslint-plugin-prettier": "^5.2.3",
+    "husky": "^9.1.7",
+    "lint-staged": "^16.2.1",
     "postcss": "^8.5.3",
     "prettier": "^3.5.3",
     "tailwindcss": "^4.0.15",
     "typescript": "^5"
+  },
+  "lint-staged": {
+    "*.{js,jsx,ts,tsx}": [
+      "eslint --fix",
+      "prettier --write"
+    ],
+    "*.{json,css,md}": [
+      "prettier --write"
+    ]
+  },
+  "config": {
+    "commitizen": {
+      "path": "./node_modules/cz-conventional-changelog"
+    }
   }
 }


### PR DESCRIPTION
#  Add Pre-commit Hooks with Husky and lint-staged

## Summary
Implements pre-commit hooks using Husky and lint-staged to ensure code quality, formatting, and conventional commits.

# Closes: #121 

## What's Added
- **Husky**: Pre-commit and commit-msg hooks
- **lint-staged**: Runs ESLint + Prettier on staged files only
- **Commitlint**: Validates conventional commit messages
- **Commitizen**: Interactive commit creation (`npm run commit`)

## Configuration
```json
// package.json
"lint-staged": {
  "*.{js,jsx,ts,tsx}": ["eslint --fix", "prettier --write"],
  "*.{json,css,md}": ["prettier --write"]
}
```

## Usage
```bash
# Interactive conventional commit
npm run commit

# Manual commit (hooks run automatically)
git commit -m "feat(auth): add user login"
```

## Benefits
- ✅ Automatic code quality checks on every commit
- ✅ Consistent formatting across all files
- ✅ Standardized commit messages
- ✅ Cleaner git history

## Testing
- [x] Pre-commit hooks tested
- [x] ESLint auto-fix verified
- [x] Prettier formatting confirmed
- [x] Commit message validation working

**No breaking changes** - purely additive functionality.
