### PR TITLE
feat(electives): add mock enrollment with student store and toast fee…

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -31,6 +31,7 @@
         "@tailwindcss/postcss": "^4.0.15",
         "@tanstack/react-query": "^5.80.6",
         "@types/styled-components": "^5.1.34",
+        "@vercel/analytics": "^1.5.0",
         "axios": "^1.9.0",
         "class-variance-authority": "^0.7.1",
         "embla-carousel-react": "^8.5.2",
@@ -4781,6 +4782,44 @@
       "os": [
         "win32"
       ]
+    },
+    "node_modules/@vercel/analytics": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@vercel/analytics/-/analytics-1.5.0.tgz",
+      "integrity": "sha512-MYsBzfPki4gthY5HnYN7jgInhAZ7Ac1cYDoRWFomwGHWEX7odTEzbtg9kf/QSo7XEsEAqlQugA6gJ2WS2DEa3g==",
+      "license": "MPL-2.0",
+      "peerDependencies": {
+        "@remix-run/react": "^2",
+        "@sveltejs/kit": "^1 || ^2",
+        "next": ">= 13",
+        "react": "^18 || ^19 || ^19.0.0-rc",
+        "svelte": ">= 4",
+        "vue": "^3",
+        "vue-router": "^4"
+      },
+      "peerDependenciesMeta": {
+        "@remix-run/react": {
+          "optional": true
+        },
+        "@sveltejs/kit": {
+          "optional": true
+        },
+        "next": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "svelte": {
+          "optional": true
+        },
+        "vue": {
+          "optional": true
+        },
+        "vue-router": {
+          "optional": true
+        }
+      }
     },
     "node_modules/@webassemblyjs/ast": {
       "version": "1.14.1",

--- a/src/app/electives/[id]/page.tsx
+++ b/src/app/electives/[id]/page.tsx
@@ -243,5 +243,3 @@ const CourseDetail = () => {
 };
 
 export default CourseDetail;
-
-export default CourseDetail;

--- a/src/services/electiveService.ts
+++ b/src/services/electiveService.ts
@@ -122,6 +122,11 @@ export interface FetchCourseByIdOptions {
   simulateError?: boolean;
 }
 
+export const MOCK_STUDENT = {
+  id: 'mock-student-id',
+  enrolledCourses: new Set<string>(),
+};
+
 export const courseService = {
   async fetchCourses(
     options: FetchCoursesOptions = {},
@@ -157,4 +162,34 @@ export const courseService = {
     const course = MOCK_COURSES.find((c) => c.id === id);
     return course || null;
   },
+
+  async enrollInCourse(
+    courseId: string,
+    options: { simulateDelay?: number; simulateError?: boolean } = {},
+  ): Promise<{ success: boolean; message: string }> {
+    const { simulateDelay = 1200, simulateError = false } = options;
+
+    await new Promise((resolve) => setTimeout(resolve, simulateDelay));
+
+    if (simulateError) {
+      throw new Error('Enrollment failed. Please try again.');
+    }
+
+    const course = MOCK_COURSES.find((c) => c.id === courseId);
+    if (!course) {
+      return { success: false, message: 'Course not found.' };
+    }
+
+    if (!course.isActive) {
+      return { success: false, message: 'Course is currently unavailable.' };
+    }
+
+    if (MOCK_STUDENT.enrolledCourses.has(courseId)) {
+      return { success: false, message: 'You are already enrolled.' };
+    }
+
+    MOCK_STUDENT.enrolledCourses.add(courseId);
+    return { success: true, message: 'Successfully enrolled!' };
+  },
 };
+


### PR DESCRIPTION
### PR Title

`feat(electives): add mock enrollment for elective courses`

---

### Description

* Added `MOCK_STUDENT` and `enrollInCourse` in `electiveService.ts` to simulate enrollment.
* Updated `[id]/page.tsx` to handle enrollment state, disable button if already enrolled, and show success/error toasts.

✅ Meets all acceptance criteria:

* Enroll button available for student role
* Updates mock store on enroll
* Button disabled if already enrolled
* Toasts for success/error

<img width="1313" height="700" alt="Screenshot from 2025-10-03 17-18-49" src="https://github.com/user-attachments/assets/8531562b-e488-439f-a908-134df8c4dee7" />


