### PR TITLE
Global toast notification system

### DIFF
--- a/src/app/code-playground/secure-playground.tsx
+++ b/src/app/code-playground/secure-playground.tsx
@@ -10,7 +10,6 @@ import {
   CardTitle,
 } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
-import { Toaster } from 'sonner';
 import { Shield, Zap, Clock, Code2, Users } from 'lucide-react';
 
 import LanguageSelector from '@/components/code-playground/language-selector';
@@ -156,8 +155,6 @@ export default function SecureCodePlayground() {
 
   return (
     <div className="container mx-auto p-4 max-w-7xl">
-      <Toaster position="top-right" />
-
       {/* Header Card */}
       <Card className="mb-6">
         <CardHeader>

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -18,7 +18,8 @@ import Footer from '../components/Footer';
 import Navbar from '../components/Navbar';
 import CookieBanner from '../components/CookieBanner';
 import Analytics from '../components/Analytics';
-import { Toaster } from 'sonner';
+import { Toaster as AppToaster } from '@/components/ui/toaster';
+import { Toaster as SonnerToaster } from 'sonner';
 import { Providers } from '../lib/providers';
 import EnvironmentValidator from '../components/EnvironmentValidator';
 import { initializeServerEnvironment } from '../lib/env-server';
@@ -177,7 +178,8 @@ export default function RootLayout({
 
             <MainLayoutWrapper>{children}</MainLayoutWrapper>
 
-            <Toaster position="top-right" />
+            <AppToaster />
+            <SonnerToaster position="top-right" />
             <Analytics />
             <CookieBanner />
           </Providers>

--- a/src/components/code-playground/collaborative-playground-client.tsx
+++ b/src/components/code-playground/collaborative-playground-client.tsx
@@ -9,7 +9,6 @@ import {
   CardTitle,
 } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
-import { Toaster } from 'sonner';
 import { Code2, Users } from 'lucide-react';
 import {
   CollaborationProvider,
@@ -124,8 +123,6 @@ function CollaborativePlaygroundContent() {
 
   return (
     <div className="container mx-auto p-2 sm:p-4 max-w-7xl">
-      <Toaster position="top-right" />
-
       {/* Header Card */}
       <Card className="mb-4 sm:mb-6">
         <CardHeader className="px-3 sm:px-6 py-3 sm:py-6">

--- a/src/components/ui/toast.tsx
+++ b/src/components/ui/toast.tsx
@@ -3,7 +3,7 @@
 import * as React from 'react';
 import * as ToastPrimitives from '@radix-ui/react-toast';
 import { cva, type VariantProps } from 'class-variance-authority';
-import { X, CheckCircle, AlertCircle, Info } from 'lucide-react';
+import { X, CheckCircle, AlertCircle, Info, TriangleAlert } from 'lucide-react';
 
 import { cn } from '@/lib/utils';
 
@@ -34,6 +34,8 @@ const toastVariants = cva(
           'destructive group border-destructive bg-destructive text-destructive-foreground',
         success:
           'border-green-200 bg-green-50 text-green-900 dark:border-green-800 dark:bg-green-900/20 dark:text-green-100',
+        warning:
+          'border-amber-200 bg-amber-50 text-amber-950 dark:border-amber-800 dark:bg-amber-950/30 dark:text-amber-100',
         info: 'border-blue-200 bg-blue-50 text-blue-900 dark:border-blue-800 dark:bg-blue-900/20 dark:text-blue-100',
       },
     },
@@ -118,12 +120,16 @@ ToastDescription.displayName = ToastPrimitives.Description.displayName;
 const ToastIcon = ({
   variant,
 }: {
-  variant?: 'default' | 'destructive' | 'success' | 'info';
+  variant?: 'default' | 'destructive' | 'success' | 'warning' | 'info';
 }) => {
   switch (variant) {
     case 'success':
       return (
         <CheckCircle className="h-5 w-5 text-green-600 dark:text-green-400" />
+      );
+    case 'warning':
+      return (
+        <TriangleAlert className="h-5 w-5 text-amber-600 dark:text-amber-400" />
       );
     case 'destructive':
       return <AlertCircle className="h-5 w-5 text-red-600 dark:text-red-400" />;

--- a/src/contexts/use-toast.ts
+++ b/src/contexts/use-toast.ts
@@ -51,9 +51,24 @@ type Action =
 
 interface State {
   toasts: ToasterToast[];
+  queue: ToasterToast[];
 }
 
 const toastTimeouts = new Map<string, ReturnType<typeof setTimeout>>();
+
+const fillToastSlots = (state: State): State => {
+  if (state.toasts.length >= TOAST_LIMIT || state.queue.length === 0) {
+    return state;
+  }
+
+  const availableSlots = TOAST_LIMIT - state.toasts.length;
+  const nextToasts = state.queue.slice(0, availableSlots);
+
+  return {
+    toasts: [...state.toasts, ...nextToasts],
+    queue: state.queue.slice(availableSlots),
+  };
+};
 
 const addToRemoveQueue = (toastId: string) => {
   if (toastTimeouts.has(toastId)) {
@@ -73,16 +88,27 @@ const addToRemoveQueue = (toastId: string) => {
 
 export const reducer = (state: State, action: Action): State => {
   switch (action.type) {
-    case 'ADD_TOAST':
+    case 'ADD_TOAST': {
+      if (state.toasts.length < TOAST_LIMIT) {
+        return {
+          ...state,
+          toasts: [action.toast, ...state.toasts],
+        };
+      }
+
       return {
         ...state,
-        toasts: [action.toast, ...state.toasts].slice(0, TOAST_LIMIT),
+        queue: [...state.queue, action.toast],
       };
+    }
 
     case 'UPDATE_TOAST':
       return {
         ...state,
         toasts: state.toasts.map((t) =>
+          t.id === action.toast.id ? { ...t, ...action.toast } : t,
+        ),
+        queue: state.queue.map((t) =>
           t.id === action.toast.id ? { ...t, ...action.toast } : t,
         ),
       };
@@ -112,23 +138,31 @@ export const reducer = (state: State, action: Action): State => {
         ),
       };
     }
-    case 'REMOVE_TOAST':
+    case 'REMOVE_TOAST': {
       if (action.toastId === undefined) {
         return {
           ...state,
           toasts: [],
+          queue: [],
         };
       }
-      return {
+
+      toastTimeouts.delete(action.toastId);
+
+      return fillToastSlots({
         ...state,
         toasts: state.toasts.filter((t) => t.id !== action.toastId),
-      };
+        queue: state.queue.filter((t) => t.id !== action.toastId),
+      });
+    }
+    default:
+      return state;
   }
 };
 
 const listeners: Array<(state: State) => void> = [];
 
-let memoryState: State = { toasts: [] };
+let memoryState: State = { toasts: [], queue: [] };
 
 function dispatch(action: Action) {
   memoryState = reducer(memoryState, action);
@@ -168,6 +202,18 @@ function toast({ ...props }: Toast) {
   };
 }
 
+const success = (props: Omit<Toast, 'variant'>) =>
+  toast({ ...props, variant: 'success' });
+
+const error = (props: Omit<Toast, 'variant'>) =>
+  toast({ ...props, variant: 'destructive' });
+
+const warning = (props: Omit<Toast, 'variant'>) =>
+  toast({ ...props, variant: 'warning' });
+
+const info = (props: Omit<Toast, 'variant'>) =>
+  toast({ ...props, variant: 'info' });
+
 function useToast() {
   const [state, setState] = React.useState<State>(memoryState);
 
@@ -179,19 +225,20 @@ function useToast() {
         listeners.splice(index, 1);
       }
     };
-  }, [state]);
+  }, []);
 
   return {
     ...state,
     toast,
     dismiss: (toastId?: string) => dispatch({ type: 'DISMISS_TOAST', toastId }),
-    success: (props: Omit<Toast, 'variant'>) =>
-      toast({ ...props, variant: 'success' }),
-    error: (props: Omit<Toast, 'variant'>) =>
-      toast({ ...props, variant: 'destructive' }),
-    info: (props: Omit<Toast, 'variant'>) =>
-      toast({ ...props, variant: 'info' }),
+    success,
+    error,
+    warning,
+    info,
   };
 }
 
-export { useToast, toast };
+type UseToast = ReturnType<typeof useToast>;
+
+export { useToast, toast, success, error, warning, info };
+export type { UseToast };

--- a/src/hooks/use-toast.ts
+++ b/src/hooks/use-toast.ts
@@ -1,19 +1,2 @@
-import { useState } from 'react';
-
-type Toast = {
-  id: string;
-  title?: string;
-  description?: string;
-  action?: React.ReactNode;
-  variant?: 'default' | 'destructive' | 'success' | 'info';
-};
-
-export function useToast() {
-  const [toasts] = useState<Toast[]>([]);
-  function push(_toast?: Partial<Toast>) {
-    /* no-op placeholder for tests and type-checking */
-  }
-  return { toasts, push } as const;
-}
-
-export type UseToast = ReturnType<typeof useToast>;
+export { useToast, toast, success, error, warning, info } from '@/contexts/use-toast';
+export type { UseToast } from '@/contexts/use-toast';


### PR DESCRIPTION
close #245 



Notification / Toast System Review

Implemented a global toast notification system for `StrellerMinds-Frontend` with support for success, error, warning, auto-dismiss, queueing, and custom durations.

What was done
- Added a shared toast store for app-wide usage.
- Mounted the toast UI globally so notifications can be triggered from anywhere.
- Added toast variants for `success`, `error`, `warning`, and existing informational usage.
- Implemented auto-dismiss behavior.
- Implemented queue support so extra toasts wait and appear as visible ones close.
- Added support for custom durations per toast.

Files updated
- [src/contexts/use-toast.ts](c:/Users/User/Desktop/StrellerMinds-Frontend/src/contexts/use-toast.ts)
- [src/components/ui/toast.tsx](c:/Users/User/Desktop/StrellerMinds-Frontend/src/components/ui/toast.tsx)
- [src/hooks/use-toast.ts](c:/Users/User/Desktop/StrellerMinds-Frontend/src/hooks/use-toast.ts)
- [src/app/layout.tsx](c:/Users/User/Desktop/StrellerMinds-Frontend/src/app/layout.tsx)

Acceptance criteria covered
- Accessible globally: yes, mounted in root layout
- Queue support: yes
- Custom durations: yes
- Success, error, warning variants: yes
- Auto-dismiss: yes

How to test
- Trigger a success, error, and warning toast from any page/component.
- Confirm toasts appear globally without adding a local provider.
- Confirm each toast auto-dismisses after its duration.
- Trigger more than 5 toasts quickly and confirm the rest are queued.
- Trigger toasts with different `duration` values and confirm timing differs.
- Close a toast manually and confirm queued toasts continue to appear.

Example usage
```ts
toast({
  title: 'Saved successfully',
  description: 'Your changes have been updated.',
  variant: 'success',
  duration: 5000,
});
```

Note
The repository currently has broader pre-existing TypeScript issues, so full project type-check was not cleanly usable as a final validation for this task. The toast implementation itself was integrated and reviewed against the required scope.