### PR TITLE
APIResponseCacheLayer Component (#321)

### DIFF
--- a/src/components/api-response/APIResponseCacheLayer.ts
+++ b/src/components/api-response/APIResponseCacheLayer.ts
@@ -1,0 +1,33 @@
+import { CacheService } from "../services/cache/CacheService";
+
+interface CacheOptions {
+  key: string;
+  ttlMs?: number;
+  invalidateOn?: string[]; // mutation endpoints
+}
+
+export async function APIResponseCacheLayer<T>(
+  fetcher: () => Promise<T>,
+  options: CacheOptions
+): Promise<T> {
+  const { key, ttlMs = 60_000 } = options;
+
+  const cached = CacheService.get<T>(key);
+  if (cached) {
+    return cached;
+  }
+
+  const result = await fetcher();
+  CacheService.set(key, result, ttlMs);
+  return result;
+}
+
+// Example mutation wrapper
+export async function invalidateOnMutation<T>(
+  mutation: () => Promise<T>,
+  keysToInvalidate: string[]
+): Promise<T> {
+  const result = await mutation();
+  keysToInvalidate.forEach((key) => CacheService.invalidate(key));
+  return result;
+}

--- a/src/services/cache/CacheService.ts
+++ b/src/services/cache/CacheService.ts
@@ -1,0 +1,30 @@
+type CacheEntry<T> = {
+  value: T;
+  expiresAt: number;
+};
+
+export class CacheService {
+  private static store = new Map<string, CacheEntry<any>>();
+
+  static get<T>(key: string): T | null {
+    const entry = this.store.get(key);
+    if (!entry) return null;
+    if (Date.now() > entry.expiresAt) {
+      this.store.delete(key);
+      return null;
+    }
+    return entry.value;
+  }
+
+  static set<T>(key: string, value: T, ttlMs: number) {
+    this.store.set(key, { value, expiresAt: Date.now() + ttlMs });
+  }
+
+  static invalidate(key: string) {
+    this.store.delete(key);
+  }
+
+  static clear() {
+    this.store.clear();
+  }
+}

--- a/src/test/apiResponseCache.spec.ts
+++ b/src/test/apiResponseCache.spec.ts
@@ -1,0 +1,29 @@
+import { APIResponseCacheLayer, invalidateOnMutation } from "../src/components/APIResponseCacheLayer";
+import { CacheService } from "../src/services/cache/CacheService";
+
+describe("APIResponseCacheLayer", () => {
+  beforeEach(() => CacheService.clear());
+
+  it("caches responses by key", async () => {
+    let count = 0;
+    const fetcher = async () => ++count;
+
+    const first = await APIResponseCacheLayer(fetcher, { key: "test" });
+    const second = await APIResponseCacheLayer(fetcher, { key: "test" });
+
+    expect(first).toBe(1);
+    expect(second).toBe(1); // cached
+  });
+
+  it("invalidates cache on mutation", async () => {
+    CacheService.set("test", { foo: "bar" }, 1000);
+    await invalidateOnMutation(async () => "mutated", ["test"]);
+    expect(CacheService.get("test")).toBeNull();
+  });
+
+  it("respects TTL", async () => {
+    CacheService.set("test", "value", 1);
+    await new Promise((r) => setTimeout(r, 10));
+    expect(CacheService.get("test")).toBeNull();
+  });
+});


### PR DESCRIPTION

## 📝 Description
### Overview
This PR introduces an **APIResponseCacheLayer** component to cache API responses and reduce duplicate fetches.

### Key Features
- **CacheService**: in-memory store with TTL
- **APIResponseCacheLayer**: wraps fetchers, caches by key
- **InvalidateOnMutation**: clears cache after mutations
- **Configurable TTL**: default 60s, adjustable per call
- **Unit tests**: caching, TTL expiry, invalidation

---

## ✅ Acceptance Criteria
- Duplicate fetches reduced  
- TTL configurable  
- Cache invalidated on mutation  
- Works with dynamic queries  

---

## 📂 File Changes
- `CacheService.ts` — caching logic  
- `APIResponseCacheLayer.ts` — wrapper component  
- `apiResponseCache.spec.ts` — unit tests  

---

Closes #321 